### PR TITLE
Add support for creating ArrayBase<T> instances backed by "real" memory-mapped files

### DIFF
--- a/nuspec/Reminiscence.nuspec
+++ b/nuspec/Reminiscence.nuspec
@@ -26,6 +26,7 @@
                 <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" />
                 <dependency id="System.Buffers" version="4.5.0" />
                 <dependency id="System.Memory" version="4.5.1" />
+                <dependency id="System.IO.MemoryMappedFiles" version="4.3.0" />
             </group>
 
             <group targetFramework=".NETStandard2.0">

--- a/src/Reminiscence/Arrays/NativeMemoryArray.cs
+++ b/src/Reminiscence/Arrays/NativeMemoryArray.cs
@@ -1,24 +1,20 @@
 ﻿#if SUPPORTS_NATIVE_MEMORY_ARRAY
 using System;
-using System.IO;
 using System.Runtime.CompilerServices;
 
 namespace Reminiscence.Arrays
 {
     /// <summary>
-    /// An array that holds instances of PDS types contiguously in virtual memory.
+    /// An array that holds instances of PDS types contiguously in virtual memory using an injected
+    /// instance of <see cref="IUnmanagedMemoryAllocator"/> to handle the actual allocations.
     /// </summary>
     /// <typeparam name="T">
     /// The type of value to be stored in the array.
     /// </typeparam>
-    public sealed unsafe class NativeMemoryArray<T> : ArrayBase<T>
+    public sealed unsafe class NativeMemoryArray<T> : NativeMemoryArrayBase<T>
         where T : unmanaged
     {
         private readonly IUnmanagedMemoryAllocator allocator;
-
-        private T* head;
-
-        private long length;
 
         private bool disposed;
 
@@ -42,31 +38,6 @@ namespace Reminiscence.Arrays
         /// Finalizes an instance of the <see cref="NativeMemoryArray{T}"/> class.
         /// </summary>
         ~NativeMemoryArray() => this.Resize(0);
-
-        /// <inheritdoc />
-        public override T this[long idx]
-        {
-            get => Unsafe.ReadUnaligned<T>(GetPointer(idx));
-            set => Unsafe.WriteUnaligned(GetPointer(idx), value);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private T* GetPointer(long idx)
-        {
-            // handle non-negative and out-of-bounds with a single test
-            if (unchecked((ulong)idx >= (ulong)this.length))
-            {
-                ThrowArgumentOutOfRangeExceptionForIndex();
-            }
-
-            return this.head + idx;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowArgumentOutOfRangeExceptionForIndex() => throw new ArgumentOutOfRangeException("idx", "Must be non-negative and less than the size of the array.");
-
-        /// <inheritdoc />
-        public override long Length => this.length;
 
         /// <inheritdoc />
         public override bool CanResize => true;
@@ -94,55 +65,12 @@ namespace Reminiscence.Arrays
 
             // this is the only line anywhere that ought to have any business calling Reallocate.
 #pragma warning disable 618
-            this.head = (T*)this.allocator.Reallocate(oldPointer: (byte*)this.head,
-                                                      oldByteCount: this.length * Unsafe.SizeOf<T>(),
-                                                      newByteCount: size * Unsafe.SizeOf<T>(),
-                                                      zeroFill: true);
+            this.HeadPointer = (T*)this.allocator.Reallocate(oldPointer: (byte*)this.HeadPointer,
+                                                             oldByteCount: this.LengthCore * Unsafe.SizeOf<T>(),
+                                                             newByteCount: size * Unsafe.SizeOf<T>(),
+                                                             zeroFill: true);
 #pragma warning restore 618
-            this.length = size;
-        }
-
-        /// <inheritdoc />
-        public override unsafe void CopyFrom(ArrayBase<T> array, long index, long start, long count)
-        {
-            if (!(array is NativeMemoryArray<T> nativeArray))
-            {
-                base.CopyFrom(array, index, start, count);
-                return;
-            }
-
-            if (start + count > nativeArray.length)
-            {
-                throw new ArgumentException("tried to copy more items than the source has available");
-            }
-
-            if (index + count > this.length)
-            {
-                throw new ArgumentException("tried to copy more items than the destination has room for");
-            }
-
-            byte* srcPtr = (byte*)(nativeArray.head + start);
-            byte* dstPtr = (byte*)(this.head + index);
-            NativeMemoryArrayHelper.memmove(dstPtr, srcPtr, count * Unsafe.SizeOf<T>());
-        }
-
-        /// <inheritdoc />
-        public override unsafe void CopyFrom(Stream stream)
-        {
-            long len = this.length * Unsafe.SizeOf<T>();
-            NativeMemoryArrayHelper.CopyFromStream(stream: stream ?? throw new ArgumentNullException(nameof(stream)),
-                                                   dst:(byte*)this.head,
-                                                   length: len);
-        }
-
-        /// <inheritdoc />
-        public override unsafe long CopyTo(Stream stream)
-        {
-            long len = this.length * Unsafe.SizeOf<T>();
-            NativeMemoryArrayHelper.CopyToStream(src: (byte*)this.head,
-                                                 stream: stream ?? throw new ArgumentNullException(nameof(stream)),
-                                                 length: len);
-            return len;
+            this.LengthCore = size;
         }
     }
 }

--- a/src/Reminiscence/Arrays/NativeMemoryArrayBase.cs
+++ b/src/Reminiscence/Arrays/NativeMemoryArrayBase.cs
@@ -1,0 +1,149 @@
+﻿#if SUPPORTS_NATIVE_MEMORY_ARRAY
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace Reminiscence.Arrays
+{
+    /// <summary>
+    /// An array that holds instances of PDS types contiguously in virtual memory.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of value to be stored in the array.
+    /// </typeparam>
+    public sealed unsafe class NativeMemoryArray<T> : ArrayBase<T>
+        where T : unmanaged
+    {
+        private readonly IUnmanagedMemoryAllocator allocator;
+
+        private T* head;
+
+        private long length;
+
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NativeMemoryArray{T}"/> class.
+        /// </summary>
+        /// <param name="allocator">
+        /// The <see cref="IUnmanagedMemoryAllocator"/> to use to allocate, reallocate, and free
+        /// contiguous blocks of virtual memory.
+        /// </param>
+        /// <param name="size">
+        /// The number of elements that the array should be able to store.
+        /// </param>
+        public NativeMemoryArray(IUnmanagedMemoryAllocator allocator, long size)
+        {
+            this.allocator = allocator ?? throw new ArgumentNullException(nameof(allocator));
+            this.Resize(size);
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="NativeMemoryArray{T}"/> class.
+        /// </summary>
+        ~NativeMemoryArray() => this.Resize(0);
+
+        /// <inheritdoc />
+        public override T this[long idx]
+        {
+            get => Unsafe.ReadUnaligned<T>(GetPointer(idx));
+            set => Unsafe.WriteUnaligned(GetPointer(idx), value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private T* GetPointer(long idx)
+        {
+            // handle non-negative and out-of-bounds with a single test
+            if (unchecked((ulong)idx >= (ulong)this.length))
+            {
+                ThrowArgumentOutOfRangeExceptionForIndex();
+            }
+
+            return this.head + idx;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowArgumentOutOfRangeExceptionForIndex() => throw new ArgumentOutOfRangeException("idx", "Must be non-negative and less than the size of the array.");
+
+        /// <inheritdoc />
+        public override long Length => this.length;
+
+        /// <inheritdoc />
+        public override bool CanResize => true;
+
+        /// <inheritdoc />
+        public override void Dispose()
+        {
+            this.Resize(0);
+            this.disposed = true;
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc />
+        public override void Resize(long size)
+        {
+            if (size < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size), size, "Must be non-negative.");
+            }
+
+            if (size != 0 && this.disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+
+            // this is the only line anywhere that ought to have any business calling Reallocate.
+#pragma warning disable 618
+            this.head = (T*)this.allocator.Reallocate(oldPointer: (byte*)this.head,
+                                                      oldByteCount: this.length * Unsafe.SizeOf<T>(),
+                                                      newByteCount: size * Unsafe.SizeOf<T>(),
+                                                      zeroFill: true);
+#pragma warning restore 618
+            this.length = size;
+        }
+
+        /// <inheritdoc />
+        public override unsafe void CopyFrom(ArrayBase<T> array, long index, long start, long count)
+        {
+            if (!(array is NativeMemoryArray<T> nativeArray))
+            {
+                base.CopyFrom(array, index, start, count);
+                return;
+            }
+
+            if (start + count > nativeArray.length)
+            {
+                throw new ArgumentException("tried to copy more items than the source has available");
+            }
+
+            if (index + count > this.length)
+            {
+                throw new ArgumentException("tried to copy more items than the destination has room for");
+            }
+
+            byte* srcPtr = (byte*)(nativeArray.head + start);
+            byte* dstPtr = (byte*)(this.head + index);
+            NativeMemoryArrayHelper.memmove(dstPtr, srcPtr, count * Unsafe.SizeOf<T>());
+        }
+
+        /// <inheritdoc />
+        public override unsafe void CopyFrom(Stream stream)
+        {
+            long len = this.length * Unsafe.SizeOf<T>();
+            NativeMemoryArrayHelper.CopyFromStream(stream: stream ?? throw new ArgumentNullException(nameof(stream)),
+                                                   dst:(byte*)this.head,
+                                                   length: len);
+        }
+
+        /// <inheritdoc />
+        public override unsafe long CopyTo(Stream stream)
+        {
+            long len = this.length * Unsafe.SizeOf<T>();
+            NativeMemoryArrayHelper.CopyToStream(src: (byte*)this.head,
+                                                 stream: stream ?? throw new ArgumentNullException(nameof(stream)),
+                                                 length: len);
+            return len;
+        }
+    }
+}
+#endif

--- a/src/Reminiscence/Arrays/NativeMemoryMappedArray.cs
+++ b/src/Reminiscence/Arrays/NativeMemoryMappedArray.cs
@@ -1,0 +1,180 @@
+﻿#if SUPPORTS_NATIVE_MEMORY_ARRAY
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.CompilerServices;
+
+namespace Reminiscence.Arrays
+{
+    /// <summary>
+    /// An array that holds instances of PDS types contiguously in virtual memory, backed by a
+    /// "real" native memory-mapped file.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of value to be stored in the array.
+    /// </typeparam>
+    public sealed unsafe class NativeMemoryMappedArray<T> : NativeMemoryArrayBase<T>
+        where T : unmanaged
+    {
+        private readonly FileStream fileStream;
+
+        private MemoryMappedFile memoryMappedFile;
+
+        private MemoryMappedViewAccessor memoryMappedViewAccessor;
+
+        private byte* acquiredPointer;
+
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NativeMemoryMappedArray{T}"/> class.
+        /// </summary>
+        /// <param name="fileName">
+        /// The path to the file to memory-map.  If the file does not exist, then it will be created
+        /// (with length 0).
+        /// </param>
+        public NativeMemoryMappedArray(string fileName)
+        {
+            // to be considered: if we accept an existing FileStream, an offset, and a byte count,
+            // then we can map just a section of the file so that multiple maps could be active at
+            // once for the same file (though the arrays would become not-resizable).
+            this.fileStream = new FileStream(fileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            try
+            {
+                this.Initialize();
+            }
+            catch
+            {
+                this.fileStream.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="NativeMemoryMappedArray{T}"/> class.
+        /// </summary>
+        ~NativeMemoryMappedArray() => this.Dispose(false);
+
+        /// <inheritdoc />
+        public override void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc />
+        public override bool CanResize => true;
+
+        /// <inheritdoc />
+        public override void Resize(long size)
+        {
+            if (size < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size), size, "Must be non-negative.");
+            }
+
+            if (size != 0 && this.disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+
+            if (size == this.LengthCore)
+            {
+                return;
+            }
+
+            long oldLength = this.LengthCore;
+
+            this.ReleaseAllButFileStream();
+
+            this.fileStream.SetLength(size * Unsafe.SizeOf<T>());
+            this.Initialize();
+
+            long newLength = this.LengthCore;
+            if (oldLength < newLength)
+            {
+                byte* oldEnd = (byte*)&this.HeadPointer[oldLength];
+                byte* newEnd = (byte*)&this.HeadPointer[newLength];
+                NativeMemoryArrayHelper.ZeroFill(oldEnd, newEnd - oldEnd);
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.ReleasePointerIfAcquired();
+
+            if (disposing)
+            {
+                this.ReleaseObjectsBetweenAcquiredPointerAndFileStream();
+                this.fileStream.Dispose();
+            }
+
+            this.disposed = true;
+        }
+
+        private void Initialize()
+        {
+            this.ReleaseAllButFileStream();
+
+            try
+            {
+                long finalLength = this.fileStream.Length / Unsafe.SizeOf<T>();
+                if (finalLength == 0)
+                {
+                    return;
+                }
+
+#if NET45
+                this.memoryMappedFile = MemoryMappedFile.CreateFromFile(this.fileStream, null, 0, MemoryMappedFileAccess.ReadWrite, null, HandleInheritability.None, leaveOpen: true);
+#else
+                this.memoryMappedFile = MemoryMappedFile.CreateFromFile(this.fileStream, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, leaveOpen: true);
+#endif
+                this.memoryMappedViewAccessor = this.memoryMappedFile.CreateViewAccessor();
+
+                this.memoryMappedViewAccessor.SafeMemoryMappedViewHandle.AcquirePointer(ref this.acquiredPointer);
+                this.HeadPointer = (T*)this.acquiredPointer;
+                this.LengthCore = finalLength;
+            }
+            catch
+            {
+                this.ReleaseAllButFileStream();
+                throw;
+            }
+        }
+
+        private void ReleaseAllButFileStream()
+        {
+            this.ReleasePointerIfAcquired();
+            this.ReleaseObjectsBetweenAcquiredPointerAndFileStream();
+        }
+
+        private void ReleasePointerIfAcquired()
+        {
+            if (this.acquiredPointer == null)
+            {
+                return;
+            }
+
+            this.memoryMappedViewAccessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            this.acquiredPointer = null;
+        }
+
+        private void ReleaseObjectsBetweenAcquiredPointerAndFileStream()
+        {
+            this.LengthCore = 0;
+            this.HeadPointer = null;
+
+            this.memoryMappedViewAccessor?.Dispose();
+            this.memoryMappedViewAccessor = null;
+
+            this.memoryMappedFile?.Dispose();
+            this.memoryMappedFile = null;
+        }
+    }
+}
+#endif

--- a/src/Reminiscence/Reminiscence.csproj
+++ b/src/Reminiscence/Reminiscence.csproj
@@ -60,6 +60,10 @@
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'portable40-net403+sl5+win8+wp8' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_NATIVE_MEMORY_ARRAY</DefineConstants>
     <SupportsNativeMemoryArray>True</SupportsNativeMemoryArray>
+
+    <!-- Memory-mapped files are not included as a part of .NET Standard 1.3, *but* this feature can
+         be added in by just importing this package. -->
+    <IncludeMemoryMappedFilePackage Condition=" '$(TargetFramework)' == 'netstandard1.3' ">True</IncludeMemoryMappedFilePackage>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|x64'" />
@@ -77,6 +81,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.IO.MemoryMappedFiles" Version="4.3.0" Condition=" '$(IncludeMemoryMappedFilePackage)' == 'True' " />
   </ItemGroup>
 
 </Project>

--- a/test/Reminiscence.Tests/Arrays/NativeMemoryMappedArrayTests.cs
+++ b/test/Reminiscence.Tests/Arrays/NativeMemoryMappedArrayTests.cs
@@ -1,0 +1,180 @@
+﻿// The MIT License (MIT)
+
+// Copyright (c) 2015 Ben Abelshausen
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using NUnit.Framework;
+using Reminiscence.Arrays;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Reminiscence.Tests.Arrays
+{
+    /// <summary>
+    /// Contains new memory mapped array tests.
+    /// </summary>
+    public class NativeMemoryMappedArrayTests : IDisposable
+    {
+        private readonly List<string> createdPaths = new List<string>();
+
+        public void Dispose() => this.createdPaths.ForEach(File.Delete);
+
+        /// <summary>
+        /// A comparison test for the huge array to a regular array.
+        /// </summary>
+        [Test]
+        public void CompareToArrayTest()
+        {
+            var intArrayRef = new int[1000];
+            var byteLength = MemoryMarshal.AsBytes(intArrayRef.AsSpan()).Length;
+            var intArray = new NativeMemoryMappedArray<int>(this.CreateFile(byteLength));
+
+            var randomGenerator = new System.Random(8675309); // make this deterministic 
+            for (var idx = 0; idx < 1000; idx++)
+            {
+                if (randomGenerator.Next(4) >= 2)
+                { // add data.
+                    intArrayRef[idx] = idx;
+                    intArray[idx] = idx;
+                }
+                else
+                {
+                    intArrayRef[idx] = 0;
+                    intArray[idx] = 0;
+                }
+            }
+
+            for (var idx = 0; idx < 1000; idx++)
+            {
+                Assert.AreEqual(intArrayRef[idx], intArray[idx]);
+            }
+
+            intArray.Dispose();
+        }
+
+        /// <summary>
+        /// A test resizing a huge array 
+        /// </summary>
+        [Test]
+        public void ResizeTest()
+        {
+            var intArrayRef = new int[1000];
+            var intArray = new NativeMemoryMappedArray<int>(this.CreateFile(1000 * sizeof(int)));
+
+            var randomGenerator = new System.Random(8675309); // make this deterministic 
+            for (int idx = 0; idx < 1000; idx++)
+            {
+                if (randomGenerator.Next(4) >= 2)
+                { // add data.
+                    intArrayRef[idx] = idx;
+                    intArray[idx] = idx;
+                }
+                else
+                {
+                    intArrayRef[idx] = 0;
+                    intArray[idx] = 0;
+                }
+            }
+
+            Array.Resize(ref intArrayRef, 335);
+            intArray.Resize(335);
+
+            Assert.AreEqual(intArrayRef.Length, intArray.Length);
+            for (int idx = 0; idx < intArrayRef.Length; idx++)
+            {
+                Assert.AreEqual(intArrayRef[idx], intArray[idx]);
+            }
+
+            intArrayRef = new int[1000];
+            intArray.Dispose();
+            intArray = new NativeMemoryMappedArray<int>(this.CreateFile(1000 * sizeof(int)));
+
+            for (int idx = 0; idx < 1000; idx++)
+            {
+                if (randomGenerator.Next(4) >= 2)
+                { // add data.
+                    intArrayRef[idx] = idx;
+                    intArray[idx] = idx;
+                }
+                else
+                {
+                    intArrayRef[idx] = 0;
+                    intArray[idx] = 0;
+                }
+            }
+
+            Array.Resize(ref intArrayRef, 1235);
+            intArray.Resize(1235);
+
+            Assert.AreEqual(intArrayRef.Length, intArray.Length);
+            for (int idx = 0; idx < intArrayRef.Length; idx++)
+            {
+                Assert.AreEqual(intArrayRef[idx], intArray[idx]);
+            }
+
+            intArray.Dispose();
+        }
+
+        [Test]
+        public void RoundTripTest()
+        {
+            var inputBytes = new byte[1024 * 1024];
+            var inputBytesAsInt32 = MemoryMarshal.Cast<byte, int>(inputBytes);
+            var randomGenerator = new System.Random(8675309); // make this deterministic
+            for (int i = 0; i < inputBytesAsInt32.Length; i++)
+            {
+                inputBytesAsInt32[i] = randomGenerator.Next();
+            }
+
+            Span<byte> outputBytes;
+            using (var arr1 = new NativeMemoryMappedArray<int>(this.CreateFile(inputBytes.Length)))
+            using (var arr2 = new NativeMemoryMappedArray<int>(this.CreateFile(inputBytes.Length)))
+            {
+                // load the data in from a stream
+                using (var ms = new MemoryStream(inputBytes, false))
+                {
+                    arr1.CopyFrom(ms);
+                }
+
+                // copy the data to another array
+                arr2.CopyFrom(arr1);
+
+                // save the data out to another stream
+                using (var ms = new MemoryStream(inputBytes.Length))
+                {
+                    arr2.CopyTo(ms);
+                    outputBytes = ms.ToArray();
+                }
+            }
+
+            Assert.True(outputBytes.SequenceEqual(inputBytes));
+        }
+
+        private string CreateFile(int length)
+        {
+            string path = Path.GetRandomFileName();
+            File.WriteAllBytes(path, new byte[length]);
+            this.createdPaths.Add(path);
+            return path;
+        }
+    }
+}

--- a/test/Reminiscence.Tests/Reminiscence.Tests.csproj
+++ b/test/Reminiscence.Tests/Reminiscence.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There's going to have to be a bit of refactoring on the Itinero side before this can be used all that effectively, since the only ways Itinero currently lets you create `ArrayBase<T>` instances seem to be:
- Create a new empty instance and then copy from an arbitrary `Stream`, or
- Create an `Array<T>` using an abstract accessor.

I still haven't quite figured out the best approach to integrate this in Itinero, but I think this is solid enough to commit to Reminiscence.  My current thought is that `RouterDb` could have methods like `Deserialize` / `DeserializeAndAddContracted`, but which accept file paths instead of arbitrary `Stream`s.  The inner types would be updated as appropriate, of course.  Still thinking about it, though, since the downside is that we'd either have to accept a lot of code duplication (eww) or add even more weird logic in the existing methods around where they check for non-`null` "profile" instances...

The way I did this was:
- Create an exact copy of `NativeMemoryArray.cs` to help with the diff for the next step.
- Split `NativeMemoryArray<T>` into two parts:
    - An abstract base class for arrays backed by contiguous virtual memory, and
    - The implementation from #18 that uses `IUnmanagedMemoryAllocator`.
- Add another subclass that uses a pointer to the data from a "real" memory-mapped file.

The new array class can work in either of two slightly different ways:
1. If you just pass in the path to a file, then we interpret it to mean that you want to use **the entire file** for your data.  In this mode, `CanResize` is true (because we can support that by resizing the file).
1. If you pass in the path to a file with an offset / length, then we support that too, but `CanResize` will be false, because resizing could mess up offsets for other readers of the same file.

The weakest part of this one: I'm not 100% sure about the values of `FileAccess`, `FileShare`, and `MemoryMappedFileAccess` that I used here.  Maybe we should be a bit more restrictive...